### PR TITLE
Fix sizing and clipping of the editor dock

### DIFF
--- a/addons/project_time_tracker/ptt_dock.tscn
+++ b/addons/project_time_tracker/ptt_dock.tscn
@@ -11,66 +11,71 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_7wcfh")
-lbl_CST = NodePath("MarginContainer/VBoxContainer/CurrentSession")
-lbl_LST = NodePath("MarginContainer/VBoxContainer/LastSession")
-lbl_TOOD = NodePath("MarginContainer/VBoxContainer/VBoxContainer/TotalOnOffDays")
-cb_sn = NodePath("MarginContainer/VBoxContainer/VBoxContainer/CheckBox")
-lbl_StartDate = NodePath("MarginContainer/VBoxContainer/StartDate")
+lbl_CST = NodePath("ScrollContainer/MarginContainer/VBoxContainer/CurrentSession")
+lbl_LST = NodePath("ScrollContainer/MarginContainer/VBoxContainer/LastSession")
+lbl_TOOD = NodePath("ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/TotalOnOffDays")
+cb_sn = NodePath("ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/CheckBox")
+lbl_StartDate = NodePath("ScrollContainer/MarginContainer/VBoxContainer/StartDate")
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="ScrollContainer" type="ScrollContainer" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 theme_override_constants/margin_left = 8
 theme_override_constants/margin_top = 8
 theme_override_constants/margin_right = 8
 theme_override_constants/margin_bottom = 8
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer/MarginContainer"]
 layout_mode = 2
 theme_override_constants/separation = 16
 
-[node name="CurrentSession" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
+[node name="CurrentSession" type="RichTextLabel" parent="ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 bbcode_enabled = true
 text = "[center]Current Session
-[color=green]02:11[/color][/center]"
+[color=green]05:46[/color][/center]"
 fit_content = true
 
-[node name="LastSession" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
+[node name="LastSession" type="RichTextLabel" parent="ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 bbcode_enabled = true
 text = "[center]Last Session
-[color=green]~ 22s[/color][/center]"
+[color=green]~ 4s[/color][/center]"
 fit_content = true
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_constants/separation = 0
 
-[node name="TotalOnOffDays" type="RichTextLabel" parent="MarginContainer/VBoxContainer/VBoxContainer"]
+[node name="TotalOnOffDays" type="RichTextLabel" parent="ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_constants/line_separation = 4
 bbcode_enabled = true
 text = "Combined Time Over [color=gold]1 Day[/color]
-[color=white]~ 13 minutes[/color]"
+[color=white]~ 24 minutes, 26 seconds[/color]"
 fit_content = true
 autowrap_mode = 2
 
-[node name="CheckBox" type="CheckBox" parent="MarginContainer/VBoxContainer/VBoxContainer"]
+[node name="CheckBox" type="CheckBox" parent="ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 0
 text = "Short Notation"
 
-[node name="StartDate" type="Label" parent="MarginContainer/VBoxContainer"]
+[node name="StartDate" type="Label" parent="ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 text = "Tracking Started:
 2024-05-23 15:20:40"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[connection signal="toggled" from="MarginContainer/VBoxContainer/VBoxContainer/CheckBox" to="." method="_on_check_box_toggled"]
+[connection signal="toggled" from="ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/CheckBox" to="." method="_on_check_box_toggled"]

--- a/addons/project_time_tracker/ptt_dock.tscn
+++ b/addons/project_time_tracker/ptt_dock.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=2 format=3 uid="uid://djywon7mdvm74"]
+[gd_scene load_steps=2 format=3 uid="uid://byvcnatlevf76"]
 
 [ext_resource type="Script" path="res://addons/project_time_tracker/ptt_dock.gd" id="1_7wcfh"]
 
 [node name="Project Time Tracker" type="Control" node_paths=PackedStringArray("lbl_CST", "lbl_LST", "lbl_TOOD", "cb_sn", "lbl_StartDate")]
+clip_contents = true
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -33,30 +34,29 @@ layout_mode = 2
 theme_override_constants/separation = 16
 
 [node name="CurrentSession" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(2.08165e-12, 88)
 layout_mode = 2
 bbcode_enabled = true
 text = "[center]Current Session
-[color=green]02:28[/color][/center]"
+[color=green]02:11[/color][/center]"
+fit_content = true
 
 [node name="LastSession" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(2.08165e-12, 88)
 layout_mode = 2
 bbcode_enabled = true
 text = "[center]Last Session
-[color=green]~ 40s[/color][/center]"
+[color=green]~ 22s[/color][/center]"
+fit_content = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_constants/separation = 0
 
 [node name="TotalOnOffDays" type="RichTextLabel" parent="MarginContainer/VBoxContainer/VBoxContainer"]
-custom_minimum_size = Vector2(2.08165e-12, 128)
 layout_mode = 2
 theme_override_constants/line_separation = 4
 bbcode_enabled = true
-text = "Combined Time Over [color=gold]12 Days[/color]
-[color=white]~ 10 hours, 1 minute, 26 seconds[/color]"
+text = "Combined Time Over [color=gold]1 Day[/color]
+[color=white]~ 13 minutes[/color]"
 fit_content = true
 autowrap_mode = 2
 
@@ -69,7 +69,7 @@ text = "Short Notation"
 [node name="StartDate" type="Label" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 text = "Tracking Started:
-2024-02-21 16:35:38"
+2024-05-23 15:20:40"
 horizontal_alignment = 1
 vertical_alignment = 1
 


### PR DESCRIPTION
The editor dock was unnecessarily big. When the dock is shrunken below a certain size, it would also clip outside of the dock itself. The size of the `RichTextLabel` nodes were set manually, which causes them to be sized disproportionally. Here's how they looked for me:
![image](https://github.com/victormajida/project-time-tracker/assets/100072467/47283eba-f5d4-4262-b908-32f2228c36cf)

I fixed it in the [first commit](https://github.com/victormajida/project-time-tracker/commit/d1d2efd650955ef98500dce10b7e325ef0d5cc6b) by setting their `custom_minimum_size`s to zero and setting `fit_content` to true, which basically handles all that automatically. I also enabled `clip_contents` on the root node of the dock, which prevents it from spilling out of the inspector.

![image](https://github.com/victormajida/project-time-tracker/assets/100072467/3c340e0c-3586-412c-bb0b-45aeb499714f)

I also added a `ScrollContainer` to the inspector, so even if the inpector panel is too small to fit it, the users can navigate through it by scrolling. This has no effect if the entire inspector fits on the panel, as the scroll will be automatically turned invisible.

![image](https://github.com/victormajida/project-time-tracker/assets/100072467/2536e0dc-4ae6-4157-81e7-ebbdf9dc017a)
